### PR TITLE
fix: prevent mkdocs reverting custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+combinator.ml


### PR DESCRIPTION
See https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains